### PR TITLE
cancel order functioning with manual cascade of product order entries

### DIFF
--- a/website/models.py
+++ b/website/models.py
@@ -96,6 +96,7 @@ class Order(models.Model):
     PaymentType, default=None, blank=True, null=True,
     on_delete=models.PROTECT
     )
+
     product = models.ManyToManyField(Product, through='ProductOrder')
     deletedDate = models.DateField(default=None, blank=True, null=True)
 

--- a/website/views.py
+++ b/website/views.py
@@ -491,9 +491,12 @@ def order_detail(request, order_id):
 
 
 def order_cancel(request, order_id):
-    ''' allows user to cancel order '''
+    ''' allows user to cancel order - product orders deleted from join table first before deleting order'''
+
     if request.method == 'POST':
       with connection.cursor() as cursor:
+
+          cursor.execute("DELETE FROM website_productorder WHERE order_id = %s", [order_id])
           cursor.execute("DELETE FROM website_order WHERE id = %s", [order_id])
 
     return HttpResponseRedirect(reverse('website:index'))
@@ -502,7 +505,7 @@ def order_cancel(request, order_id):
 def order_product_to_delete(request, order_product_to_delete):
     ''' allows user to delete product from order '''
 
-    sql='''SELECT * FROM website_productorder p 
+    sql='''SELECT * FROM website_productorder p
     WHERE p.id = %s
     '''
     product_order_id = ProductOrder.objects.raw(sql, [order_product_to_delete])[0]


### PR DESCRIPTION
Closes #10 

Description of Proposed Changes
User can cancel an open order before payment is applied. When order is canceled, any product-order relationships will be deleted as well.

Steps to Test

`git fetch --all`
`git checkout bn-cancel-order`

open up DB Browser and go to the website_productorder table and make note of last entry id
when logged in, select a product and add to order. 
in DB Browser check website_productorder table to confirm new entry and also note order_id attached to entry
when on order detail page, click the 'cancel order' button
you should be taken to index page.
in DB Browser, check website_productorder table to confirm entry has been deleted and then go to website_order table to check order_id has been deleted as well.

Impacted Areas in Application
List general components of the application that this PR will affect:
views.py

Mentions @ousamasama 
@laboyd001 
@CurtainUp 